### PR TITLE
Register ejs require extension

### DIFF
--- a/lib/ejs/index.js
+++ b/lib/ejs/index.js
@@ -175,3 +175,15 @@ exports.render = function(str, options){
     }
     return fn.call(options.scope, options.locals || {});
 };
+
+
+if (require.extensions) {
+    require.extensions['.ejs'] = function(module, filename) {
+        source = require('fs').readFileSync(filename, 'utf-8');
+        module._compile(compile(source, {}), filename);
+     };
+} else if (require.registerExtension) {
+    require.registerExtension('.ejs', function(src) {
+        return compile(src, {});
+    });
+}


### PR DESCRIPTION
Registering "ejs" as a template extension allows you to treat templates as regular JS code.

```
// views/show.ejs
Hello <%= name %>

var showTemplate = require("./views/show");
showTemplate({ name: "Josh" });
```

_[Eco provides the same hook](https://github.com/sstephenson/eco/blob/master/lib/eco/compiler.coffee#L65-71)_
