### PR TITLE
Fixes function 'filtered' to allow for | and : in quoted arguments. Parti

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -1,4 +1,3 @@
-
 /*!
  * EJS
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -53,10 +52,10 @@ exports.clearCache = function(){
  */
 
 function filtered(js) {
-  return js.substr(1).split('|').reduce(function(js, filter){
+  return js.substr(1).match(/(([^'"| ]+|(['"])(\\.|.)*?\3)+)/g).reduce(function(js, filter){
     var parts = filter.split(':')
       , name = parts.shift()
-      , args = parts.shift() || '';
+      , args = parts.join(':'); //Now allows colons in quoted parts
     if (args) args = ', ' + args;
     return 'filters.' + name + '(' + js + args + ')';
   });


### PR DESCRIPTION
Fixes function 'filtered' to allow for | and : in quoted arguments. Particularly useful for the 'replace' filter, of the current ones.
