### PR TITLE
Modify buf from inner calls for helpers with html injection

### DIFF
--- a/lib/ejs/index.js
+++ b/lib/ejs/index.js
@@ -76,7 +76,7 @@ var parse = exports.parse = function(str, options){
         close = options.close || exports.close || '%>';
 
     var buf = [
-        "var buf = [];",
+        "var buf = []; arguments.callee.buf = buf;",
         "\nwith (locals) {",
         "\n  buf.push('"
     ];


### PR DESCRIPTION
Hi! I want to be able to inject html code from html helpers called from main template. For example:

```
<% formTag({action: '/some/action'}, function (form) { %>
    <%- form.input('name'); %>
<% }); %>
```

To implement formTag helper I need access to buf variable of template. It can be accessed as arguments.callee.caller.buf, if you will publish buf local variable. Previously I have done this via monkey-patching ejs module, but this solution is no longer acceptable since new npm policy, that forces user to use local copies of npm package.

Thanks,
Anatoliy
