### PR TITLE
Added trailing semicolon to minified js file via Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ ejs.min.js: ejs.js
 	@uglifyjs $(UGLIFY_FLAGS) $< > $@ \
 		&& du ejs.min.js \
 		&& du ejs.js
+	@echo \; >>ejs.min.js
 
 clean:
 	rm -f ejs.js


### PR DESCRIPTION
can break when aggregated with other files that follow the
(function(){})(); encapsulation pattern.
