### PR TITLE
Include filename in error message for compile errors

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -196,7 +196,16 @@ var compile = exports.compile = function(str, options){
   ].join("\n");
   
   if (options.debug) console.log(str);
-  var fn = new Function('locals, filters, escape', str);
+  try {
+    var fn = new Function('locals, filters, escape', str);
+  } catch(e) {
+      if(filename != 'undefined') {
+        e.message += ' in ' + filename;
+      }
+      
+    throw e;
+  }
+
   return function(locals){
     return fn.call(this, locals, filters, utils.escape);
   }

--- a/test/ejs.test.js
+++ b/test/ejs.test.js
@@ -286,5 +286,21 @@ module.exports = {
       var lineno = parseInt(err.toString().match(/ejs:(\d+)\n/)[1]);
       assert.deepEqual(lineno, 6, "Error should been thrown on line 3, was thrown on line "+lineno);
     }
+  },
+
+  'test compile error reports filename': function(){
+    var str = [
+      '<% if(true) {',
+      '<p>Forgot to close the tag</p>',
+      '<% } %>'
+    ].join('\n'),
+    filename = 'test/fakefile.ejs',
+    options = { filename: filename };
+
+    try {
+      ejs.compile(str, options);
+    } catch (err) {
+      assert.ok(~err.message.indexOf(filename));
+    }
   }
 };


### PR DESCRIPTION
For: https://github.com/visionmedia/ejs/issues/38

Appends the filename to the Error message when there's an error during template compilation.
