### PR TITLE
Fix capitalisation of zero length strings

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -27,7 +27,7 @@ exports.last = function(obj) {
 
 exports.capitalize = function(str){
   str = String(str);
-  return str[0].toUpperCase() + str.substr(1, str.length);
+  return str.charAt(0).toUpperCase() + str.substr(1, str.length);
 };
 
 /**


### PR DESCRIPTION
Capitalisation of zero length strings tried to uppercase undefined due to typeof str[0] === 'undefined', .charAt(0) fixes this by returning an empty string if the char does not exist.
