### PR TITLE
Don't allow '//' comments to eat the rest of the document. Closes #62

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -163,7 +163,10 @@ var parse = exports.parse = function(str, options){
 
       while (~(n = js.indexOf("\n", n))) n++, lineno++;
       if (js.substr(0, 1) == ':') js = filtered(js);
-      if (js) buf.push(prefix, js, postfix);
+      if (js) {
+        if (js.lastIndexOf('//') > js.lastIndexOf('\n')) js += '\n';
+        buf.push(prefix, js, postfix);
+      }
       i += end - start + close.length - 1;
 
     } else if (str.substr(i, 1) == "\\") {

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -185,3 +185,10 @@ describe('includes', function(){
       .should.equal(fixture('include.css.html'));
   })
 })
+
+describe('comments', function() {
+  it('should fully render with comments removed', function() {
+    ejs.render(fixture('comments.ejs'))
+      .should.equal(fixture('comments.html'));
+  })
+})

--- a/test/fixtures/comments.ejs
+++ b/test/fixtures/comments.ejs
@@ -1,0 +1,5 @@
+<li><a href="foo"><% // double-slash comment %>foo</li>
+<li><a href="bar"><% /* C-style comment */ %>bar</li>
+<li><a href="baz"><% // double-slash comment with newline
+    %>baz</li>
+<li><a href="qux"><% var x = 'qux'; // double-slash comment @ end of line %><%= x %></li>

--- a/test/fixtures/comments.html
+++ b/test/fixtures/comments.html
@@ -1,0 +1,4 @@
+<li><a href="foo">foo</li>
+<li><a href="bar">bar</li>
+<li><a href="baz">baz</li>
+<li><a href="qux">qux</li>


### PR DESCRIPTION
Currently using double-slash comments causes the remainder of the document to be skipped. See issue #62. Fixes by inserting a newline if “//” is found in an EJS block without a newline following it. Added a unit test.
