### PR TITLE
pass compileDebug option to include

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -157,7 +157,7 @@ var parse = exports.parse = function(str, options){
         if (!filename) throw new Error('filename option is required for includes');
         var path = resolveInclude(name, filename);
         include = read(path, 'utf8');
-        include = exports.parse(include, { filename: path, _with: false, open: open, close: close });
+        include = exports.parse(include, { filename: path, _with: false, open: open, close: close, compileDebug: compileDebug });
         buf.push("' + (function(){" + include + "})() + '");
         js = '';
       }

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -203,6 +203,17 @@ describe('includes', function(){
     ejs.render(fixture('include.css.ejs'), { filename: file, pets: users })
       .should.equal(fixture('include.css.html'));
   })
+
+  it('should pass compileDebug to include', function(){
+    var file = 'test/fixtures/include.ejs';
+    var fn = ejs.compile(fixture('include.ejs'), { filename: file, open: '[[', close: ']]', compileDebug: false, client: true })
+    var str = fn.toString();
+    eval('var preFn = ' + str);
+    str.should.not.match(/__stack/);
+    (function() {
+      preFn({ pets: users });
+    }).should.not.throw();
+  })
 })
 
 describe('comments', function() {


### PR DESCRIPTION
When compiling includes for client side use,  __stack doesn't exist so it throws an error.  This is because compileDebug isn't passed through when rendering includes.
