### PR TITLE
Allow named functions with no breaking 'with' scope

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -114,7 +114,7 @@ var parse = exports.parse = function(str, options){
     , buf = [];
 
   buf.push('var buf = [];');
-  if (false !== options._with) buf.push('\nwith (locals || {}) {');
+  if (false !== options._with) buf.push('\nwith (locals || {}) { (function () { ');
   buf.push('\n buf.push(\'');
 
   var lineno = 1;
@@ -188,7 +188,7 @@ var parse = exports.parse = function(str, options){
     }
   }
 
-  if (false !== options._with) buf.push("');\n}\nreturn buf.join('');")
+  if (false !== options._with) buf.push("'); })();\n} \nreturn buf.join('');")
   else buf.push("');\nreturn buf.join('');");
 
   return buf.join('');


### PR DESCRIPTION
Hi TJ,

This fix for named functions in views. Sometimes very useful to have named function in view (temporary helper). Unfortunately, in current implementation named function breaks `with (locals) {` scope. As result member of locals not available in body of named function:

``` javascript
with ({a: 1}) {
    fn(); // error a is not defined

    function fn() {
        console.log(a);
    }
}
```

To fix it I suggest to wrap with body with anonymous function, which will save locals scope for named functions defined in view:

``` javascript
with ({a: 1}) { (function () {
    fn(); // 1

    function fn() {
        console.log(a);
    }
})(); }
```

Thanks,
Anatoliy
