### PR TITLE
Fix tests on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ all: ejs.min.js
 
 test:
 	@./node_modules/.bin/mocha \
-		--require should \
 		--reporter spec
 
 ejs.js: $(SRC)

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -175,7 +175,7 @@ var parse = exports.parse = function(str, options){
     } else if (str.substr(i, 1) == "'") {
       buf.push("\\'");
     } else if (str.substr(i, 1) == "\r") {
-      buf.push(" ");
+      //ignore \r
     } else if (str.substr(i, 1) == "\n") {
       if (consumeEOL) {
         consumeEOL = false;

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -5,14 +5,14 @@
 var ejs = require('..')
   , fs = require('fs')
   , read = fs.readFileSync
-  , assert = require('assert');
+  , assert = require('should');
 
 /**
  * Load fixture `name`.
  */
 
 function fixture(name) {
-  return read('test/fixtures/' + name, 'utf8');
+  return read('test/fixtures/' + name, 'utf8').replace(/\r/g, '');
 }
 
 /**


### PR DESCRIPTION
`\r` shouldn't become a space, it should be ignored.  Because we're ignoring the `\r` character in the lib, we need to remove it from our expected results.  Requiring `should` at the top of the tests lets you run tests simply as `mocha` which is useful for people without make.
