### PR TITLE
Throw better syntax errors

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -231,7 +231,15 @@ var compile = exports.compile = function(str, options){
   if (options.debug) console.log(str);
   if (client) str = 'escape = escape || ' + utils.escape.toString() + ';\n' + str;
 
-  var fn = new Function('locals, filters, escape', str);
+  try {
+    var fn = new Function('locals, filters, escape', str);
+  } catch (ex) {
+    if (ex.name === 'SyntaxError') {
+      throw new SyntaxError(ex.message + (options.filename ? ' in ' + filename : ' while compiling an ejs template'), filename);
+    } else {
+      throw ex;
+    }
+  }
 
   if (client) return fn;
 

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -30,6 +30,29 @@ describe('ejs.compile(str, options)', function(){
     fn().should.equal('<p>yay</p>');
   })
 
+  it('should throw if there are syntax errors', function(){
+    try {
+      ejs.compile(fixture('fail.ejs'));
+    } catch (ex) {
+      if (ex.name == 'SyntaxError') {
+        ex.message.indexOf('compiling ejs').should.be.greaterThan(0);
+      } else {
+        throw ex;
+      }
+      try {
+        ejs.compile(fixture('fail.ejs'), {filename: 'fail.ejs'});
+      } catch (ex) {
+        if (ex.name == 'SyntaxError') {
+          ex.message.indexOf('fail.ejs').should.be.greaterThan(0);
+        } else {
+          throw ex;
+        }
+        return;
+      }
+    }
+    assert(false, 'compiling a file with invalid syntax should throw an exception');
+  })
+
   it('should allow customizing delimiters', function(){
     var fn = ejs.compile('<p>{= name }</p>', { open: '{', close: '}' });
     fn({ name: 'tobi' }).should.equal('<p>tobi</p>');

--- a/test/fixtures/fail.ejs
+++ b/test/fixtures/fail.ejs
@@ -1,0 +1,1 @@
+<% function foo() return 'foo'; %>


### PR DESCRIPTION
Catch syntax errors when compiling the EJS template and attach the file-name of the template for easier debugging.

This keeps biting me (and people I work with) because they keep going "I have a syntax error in a file" but have no idea which file.  This tells you which file if it can, and failing that at least tells you it's in an EJS template.
