### PR TITLE
Support `npm test` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "should": "*"
   },
   "main": "./lib/ejs.js",
-  "repository": "git://github.com/visionmedia/ejs.git"
+  "repository": "git://github.com/visionmedia/ejs.git",
+  "scripts": {
+    "test": "mocha --require should --reporter spec"
+  }
 }


### PR DESCRIPTION
This is required to work with travis-ci (otherwise it doesn't actually do anything) and it also helps windows users because they can just run:

```
npm install
npm test
```

without having to manually read the make file (or get a make for windows alternative).

If you merge this then log into travis-ci and enable this repository then all your pull-requests will say whether or not they break tests :smile:
