### PR TITLE
Slurp newlines from includes

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -157,6 +157,7 @@ var parse = exports.parse = function(str, options){
         if (!filename) throw new Error('filename option is required for includes');
         var path = resolveInclude(name, filename);
         include = read(path, 'utf8');
+        if (consumeEOL) include = include.replace(/\n/g, '');
         include = exports.parse(include, { filename: path, _with: false, open: open, close: close, compileDebug: compileDebug });
         buf.push("' + (function(){" + include + "})() + '");
         js = '';


### PR DESCRIPTION
I'm using ejs as part of a compilation process to concat some JS together and now, I'd like to use it to slurp in some templates as JS variables.

I'm not sure if this needs new syntax, or re-using the existing newline slurping syntax makes sense for includes. What I did felt like a bit of a hack, but it worked.

The idea is that with this you can do:

```
var foobar = '<% include foobar.tpl -%>';
```

and it'll slurp all the newlines from the included file.
