### PR TITLE
Make escaping customizable

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -205,7 +205,7 @@ var parse = exports.parse = function(str, options){
 
 var compile = exports.compile = function(str, options){
   options = options || {};
-  var escapeFn = options.escapeFn || utils.escape;
+  var escape = options.escape || utils.escape;
   
   var input = JSON.stringify(str)
     , compileDebug = options.compileDebug !== false
@@ -230,7 +230,7 @@ var compile = exports.compile = function(str, options){
   }
   
   if (options.debug) console.log(str);
-  if (client) str = 'escape = escape || ' + escapeFn.toString() + ';\n' + str;
+  if (client) str = 'escape = escape || ' + escape.toString() + ';\n' + str;
 
   try {
     var fn = new Function('locals, filters, escape', str);
@@ -246,7 +246,7 @@ var compile = exports.compile = function(str, options){
   if (client) return fn;
 
   return function(locals){
-    return fn.call(this, locals, filters, escapeFn);
+    return fn.call(this, locals, filters, escape);
   }
 };
 


### PR DESCRIPTION
I'm using EJS as template engine for LaTeX Code and there I don't have any usage for the html escaping. It would be very helpful to have a way for providing a custom escape function. I've implemented this using the options object in this commit.
