### PR TITLE
Support for Express 'view engine' extension setting in 'include' statement

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -93,7 +93,7 @@ function rethrow(err, str, filename, lineno){
     + lineno + '\n'
     + context + '\n\n'
     + err.message;
-  
+
   throw err;
 }
 
@@ -123,7 +123,7 @@ var parse = exports.parse = function(str, options){
   for (var i = 0, len = str.length; i < len; ++i) {
     if (str.slice(i, open.length + i) == open) {
       i += open.length
-  
+
       var prefix, postfix, line = (compileDebug ? '__stack.lineno=' : '') + lineno;
       switch (str.substr(i, 1)) {
         case '=':
@@ -155,7 +155,7 @@ var parse = exports.parse = function(str, options){
       if (0 == js.trim().indexOf('include')) {
         var name = js.trim().slice(7).trim();
         if (!filename) throw new Error('filename option is required for includes');
-        var path = resolveInclude(name, filename);
+        var path = resolveInclude(name, filename, options);
         include = read(path, 'utf8');
         include = exports.parse(include, { filename: path, _with: false, open: open, close: close, compileDebug: compileDebug });
         buf.push("' + (function(){" + include + "})() + '");
@@ -206,14 +206,14 @@ var parse = exports.parse = function(str, options){
 var compile = exports.compile = function(str, options){
   options = options || {};
   var escape = options.escape || utils.escape;
-  
+
   var input = JSON.stringify(str)
     , compileDebug = options.compileDebug !== false
     , client = options.client
     , filename = options.filename
         ? JSON.stringify(options.filename)
         : 'undefined';
-  
+
   if (compileDebug) {
     // Adds the fancy stack trace meta info
     str = [
@@ -228,7 +228,7 @@ var compile = exports.compile = function(str, options){
   } else {
     str = exports.parse(str, options);
   }
-  
+
   if (options.debug) console.log(str);
   if (client) str = 'escape = escape || ' + escape.toString() + ';\n' + str;
 
@@ -321,15 +321,20 @@ exports.renderFile = function(path, options, fn){
  *
  * @param {String} name
  * @param {String} filename
+ * @param {Object} options [optional]
  * @return {String}
  * @api private
  */
 
-function resolveInclude(name, filename) {
-  var path = join(dirname(filename), name);
-  var ext = extname(name);
-  if (!ext) path += '.ejs';
-  return path;
+function resolveInclude(name, filename, options) {
+	var path = join(dirname(filename), name);
+	var ext = extname(name);
+	var defaultExt = '.ejs';
+	if (options && options.settings && options.settings['view engine']) {
+		defaultExt = '.'+options.settings['view engine'];
+	}
+	if (!ext) path += defaultExt;
+	return path;
 }
 
 // express support


### PR DESCRIPTION
Hello, I found and fixed next problem with 'include' statement: when I set 'view engine' setting via Express (app.set('view engine', 'html') for example) I can put filepath of the view in the 'res.render' function without extension, but when I want put filepath without extension in 'include' statement in view it will cause an error, because default extension for included files is only '.ejs'. I fixed this issue by adding support for extension from 'view engine' option when it set.
