### PR TITLE
Should not catch exception that threw by callback

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -305,15 +305,16 @@ exports.renderFile = function(path, options, fn){
 
   options.filename = path;
 
+  var str;
   try {
-    var str = options.cache
+    str = options.cache
       ? cache[key] || (cache[key] = read(path, 'utf8'))
       : read(path, 'utf8');
-
-    fn(null, exports.render(str, options));
   } catch (err) {
     fn(err);
+    return;
   }
+  fn(null, exports.render(str, options));
 };
 
 /**

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -107,6 +107,25 @@ describe('ejs.renderFile(path, options, fn)', function(){
       done();
     });
   })
+
+  it('should not catch err threw by callback', function(done){
+    var options = { name: 'tj', open: '{', close: '}' };
+    var counter = 0;
+    try {
+      ejs.renderFile('test/fixtures/user.ejs', options, function(err, html){
+        counter++;
+        if (err) {
+          err.message.should.not.equal('Exception in callback');
+          return done(err);
+        }
+        throw new Error('Exception in callback');
+      });
+    } catch (err) {
+      counter.should.equal(1);
+      err.message.should.equal('Exception in callback');
+      done();
+    }
+  })
 })
 
 describe('<%=', function(){


### PR DESCRIPTION
When exception threw by callback, the callback will be executed twice.
