### PR TITLE
add link to live runnable of ejs examples dir

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,3 @@
-
 # EJS
 
 Embedded JavaScript templates.
@@ -25,6 +24,10 @@ Embedded JavaScript templates.
     <% if (user) { %>
 	    <h2><%= user.name %></h2>
     <% } %>
+    
+## Try out a live example now
+
+<a href="https://runnable.com/ejs" target="_blank"><img src="https://runnable.com/external/styles/assets/runnablebtn.png" style="width:67px;height:25px;"></a>
 
 ## Usage
 


### PR DESCRIPTION
add a runnable button to the readme.md that links to a live runnable version of the samples in the ejs 'examples' dir
