### PR TITLE
add `options.parsePlus`: Use `buf +=` instead of `buf.push()`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,7 @@ Embedded JavaScript templates.
   - `scope`           Function execution context
   - `debug`           Output generated function body
   - `compileDebug`    When `false` no debug instrumentation is compiled
+  - `parsePlus`       Use `buf +=` instead of `buf.push()`
   - `client`          Returns standalone compiled function
   - `open`            Open tag, defaulting to "<%"
   - `close`           Closing tag, defaulting to "%>"

--- a/benchmark2.js
+++ b/benchmark2.js
@@ -1,0 +1,63 @@
+var ejs = require('./');
+var Benchmark = require('benchmark');
+
+var TPL = '\
+<% if (locals.user) { %>\n\
+  <h2>hello, <%= locals.user.name %> <%= locals.user.not_exists %></h2>\n\
+  <p><%- locals.user.title %></p>\n\
+<% } %>';
+
+var render = ejs.compile(TPL, {debug: false});
+var render_ParsePlus = ejs.compile(TPL, {parsePlus: true, debug: false});
+var renderNoCompileDebug = ejs.compile(TPL, {compileDebug: false, debug: false});
+var renderNoWith = ejs.compile(TPL, {_with: false, debug: false});
+var render_ParsePlus_NoWith = ejs.compile(TPL, {parsePlus: true, _with: false, debug: false});
+console.log('renderNoCompileDebugNoWith source:\n');
+var renderNoCompileDebugNoWith = ejs.compile(TPL, {_with: false, compileDebug: false, debug: true});
+console.log('--------------------------------------------------------------');
+console.log('render_ParsePlus_NoCompileDebugNoWith source:\n');
+var render_ParsePlus_NoCompileDebugNoWith = ejs.compile(TPL, {parsePlus: true, _with: false, compileDebug: false, debug: true});
+console.log('--------------------------------------------------------------');
+
+var data = {user: {name: 'fengmk2'}};
+
+var s = render(data);
+console.log('render:', s);
+s = renderNoWith(data);
+console.log('renderNoWith:', s);
+s = renderNoCompileDebug(data);
+console.log('renderNoCompileDebug:', s);
+s = renderNoCompileDebugNoWith(data);
+console.log('renderNoCompileDebugNoWith:', s);
+s = render_ParsePlus_NoWith(data);
+console.log('render_ParsePlus_NoWith:', s);
+s = render_ParsePlus(data);
+console.log('render_ParsePlus:', s);
+s = render_ParsePlus_NoCompileDebugNoWith(data);
+console.log('render_ParsePlus_NoCompileDebugNoWith:', s);
+
+var suite = new Benchmark.Suite();
+
+suite.add('render()', function () {
+  render(data);
+}).add('renderNoCompileDebug()', function () {
+  renderNoCompileDebug(data);
+}).add('renderNoWith()', function () {
+  renderNoWith(data);
+}).add('renderNoCompileDebugNoWith()', function () {
+  renderNoCompileDebugNoWith(data);
+}).add('render_ParsePlus()', function () {
+  render_ParsePlus(data);
+}).add('render_ParsePlus_NoWith()', function () {
+  render_ParsePlus_NoWith(data);
+}).add('render_ParsePlus_NoCompileDebugNoWith()', function () {
+  render_ParsePlus_NoCompileDebugNoWith(data);
+});
+
+suite.on('cycle', function (event) {
+  console.log(String(event.target));
+})
+.on('complete', function () {
+  console.log('Fastest is ' + this.filter('fastest').pluck('name'));
+})
+.run({ async: true });

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -105,6 +105,103 @@ function rethrow(err, str, filename, lineno){
  * @api public
  */
 
+var parsePlus = exports.parsePlus = function(str, options){
+  var options = options || {}
+    , open = options.open || exports.open || '<%'
+    , close = options.close || exports.close || '%>'
+    , filename = options.filename
+    , compileDebug = options.compileDebug !== false
+    , buf = [];
+
+  buf.push('var buf = "";');
+  if (false !== options._with) buf.push('\nwith (locals || {}) { (function(){ ');
+  buf.push('\n buf += \'');
+
+  var lineno = 1;
+
+  var consumeEOL = false;
+  for (var i = 0, len = str.length; i < len; ++i) {
+    if (str.slice(i, open.length + i) == open) {
+      i += open.length
+  
+      var prefix, postfix, line = (compileDebug ? '__stack.lineno=' : '') + lineno;
+      switch (str.substr(i, 1)) {
+        case '=':
+          prefix = "' + escape((" + line + ', ';
+          postfix = ")) + '";
+          ++i;
+          break;
+        case '-':
+          prefix = "' + (" + line + ', ';
+          postfix = ") + '";
+          ++i;
+          break;
+        default:
+          prefix = "';" + line + ';';
+          postfix = "; buf += '";
+      }
+
+      var end = str.indexOf(close, i)
+        , js = str.substring(i, end)
+        , start = i
+        , include = null
+        , n = 0;
+
+      if ('-' == js[js.length-1]){
+        js = js.substring(0, js.length - 2);
+        consumeEOL = true;
+      }
+
+      if (0 == js.trim().indexOf('include')) {
+        var name = js.trim().slice(7).trim();
+        if (!filename) throw new Error('filename option is required for includes');
+        var path = resolveInclude(name, filename);
+        include = read(path, 'utf8');
+        include = exports.parsePlus(include, { filename: path, _with: false, open: open, close: close, compileDebug: compileDebug });
+        buf.push("' + (function(){" + include + "})() + '");
+        js = '';
+      }
+
+      while (~(n = js.indexOf("\n", n))) n++, lineno++;
+      if (js.substr(0, 1) == ':') js = filtered(js);
+      if (js) {
+        if (js.lastIndexOf('//') > js.lastIndexOf('\n')) js += '\n';
+        buf.push(prefix, js, postfix);
+      }
+      i += end - start + close.length - 1;
+
+    } else if (str.substr(i, 1) == "\\") {
+      buf.push("\\\\");
+    } else if (str.substr(i, 1) == "'") {
+      buf.push("\\'");
+    } else if (str.substr(i, 1) == "\r") {
+      // ignore
+    } else if (str.substr(i, 1) == "\n") {
+      if (consumeEOL) {
+        consumeEOL = false;
+      } else {
+        buf.push("\\n");
+        lineno++;
+      }
+    } else {
+      buf.push(str.substr(i, 1));
+    }
+  }
+
+  if (false !== options._with) buf.push("'; })();\n} \nreturn buf;")
+  else buf.push("';\nreturn buf;");
+
+  return buf.join('');
+};
+
+/**
+ * Parse the given `str` of ejs, returning the function body.
+ *
+ * @param {String} str
+ * @return {String}
+ * @api public
+ */
+
 var parse = exports.parse = function(str, options){
   var options = options || {}
     , open = options.open || exports.open || '<%'
@@ -220,13 +317,13 @@ var compile = exports.compile = function(str, options){
       'var __stack = { lineno: 1, input: ' + input + ', filename: ' + filename + ' };',
       rethrow.toString(),
       'try {',
-      exports.parse(str, options),
+      options.parsePlus ? exports.parsePlus(str, options) : exports.parse(str, options),
       '} catch (err) {',
       '  rethrow(err, __stack.input, __stack.filename, __stack.lineno);',
       '}'
     ].join("\n");
   } else {
-    str = exports.parse(str, options);
+    str = options.parsePlus ? exports.parsePlus(str, options) : exports.parse(str, options);
   }
   
   if (options.debug) console.log(str);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "keywords": ["template", "engine", "ejs"],
   "devDependencies": {
+    "benchmark": "*",
     "mocha": "*",
     "should": "*"
   },

--- a/test/ejs_parse_plus.js
+++ b/test/ejs_parse_plus.js
@@ -1,0 +1,269 @@
+/**
+ * Module dependencies.
+ */
+
+var ejs = require('..')
+  , fs = require('fs')
+  , read = fs.readFileSync
+  , assert = require('should');
+
+/**
+ * Load fixture `name`.
+ */
+
+function fixture(name) {
+  return read('test/fixtures/' + name, 'utf8').replace(/\r/g, '');
+}
+
+/**
+ * User fixtures.
+ */
+
+var users = [];
+users.push({ name: 'tobi' });
+users.push({ name: 'loki' });
+users.push({ name: 'jane' });
+
+describe('using options.parsePlus = true', function () {
+  describe('ejs.compile(str, options)', function(){
+    it('should compile to a function', function(){
+      var fn = ejs.compile('<p>yay</p>', { parsePlus: true });
+      fn().should.equal('<p>yay</p>');
+    })
+
+    it('should throw if there are syntax errors', function(){
+      try {
+        ejs.compile(fixture('fail.ejs'), { parsePlus: true });
+      } catch (err) {
+        err.message.should.include('compiling ejs');
+
+        try {
+          ejs.compile(fixture('fail.ejs'), { filename: 'fail.ejs', parsePlus: true });
+        } catch (err) {
+          err.message.should.include('fail.ejs');
+          return;
+        }
+      }
+
+      assert(false, 'compiling a file with invalid syntax should throw an exception');
+    })
+
+    it('should allow customizing delimiters', function(){
+      var fn = ejs.compile('<p>{= name }</p>', { open: '{', close: '}', parsePlus: true });
+      fn({ name: 'tobi' }).should.equal('<p>tobi</p>');
+
+      var fn = ejs.compile('<p>::= name ::</p>', { open: '::', close: '::', parsePlus: true });
+      fn({ name: 'tobi' }).should.equal('<p>tobi</p>');
+
+      var fn = ejs.compile('<p>(= name )</p>', { open: '(', close: ')', parsePlus: true });
+      fn({ name: 'tobi' }).should.equal('<p>tobi</p>');
+    })
+
+    it('should default to using ejs.open and ejs.close', function(){
+      ejs.open = '{';
+      ejs.close = '}';
+      var fn = ejs.compile('<p>{= name }</p>', { parsePlus: true });
+      fn({ name: 'tobi' }).should.equal('<p>tobi</p>');
+
+      var fn = ejs.compile('<p>|= name |</p>', { open: '|', close: '|', parsePlus: true });
+      fn({ name: 'tobi' }).should.equal('<p>tobi</p>');
+      delete ejs.open;
+      delete ejs.close;
+    })
+
+    it('should have a working client option', function(){
+      var fn = ejs.compile('<p><%= foo %></p>', { client: true, parsePlus: true });
+      var str = fn.toString();
+      eval('var preFn = ' + str);
+      preFn({ foo: 'bar' }).should.equal('<p>bar</p>');
+    })
+  })
+
+  describe('ejs.render(str, options)', function(){
+    it('should render the template', function(){
+      ejs.render('<p>yay</p>', { parsePlus: true })
+        .should.equal('<p>yay</p>');
+    })
+
+    it('should accept locals', function(){
+      ejs.render('<p><%= name %></p>', { name: 'tobi', parsePlus: true })
+        .should.equal('<p>tobi</p>');
+    })
+  })
+
+  describe('ejs.renderFile(path, options, fn)', function(){
+    it('should render a file', function(done){
+      ejs.renderFile('test/fixtures/para.ejs', { parsePlus: true }, function(err, html){
+        if (err) return done(err);
+        html.should.equal('<p>hey</p>');
+        done();
+      });
+    })
+
+    it('should accept locals', function(done){
+      var options = { name: 'tj', open: '{', close: '}', parsePlus: true };
+      ejs.renderFile('test/fixtures/user.ejs', options, function(err, html){
+        if (err) return done(err);
+        html.should.equal('<h1>tj</h1>');
+        done();
+      });
+    })
+
+    it('should not catch err threw by callback', function(done){
+      var options = { name: 'tj', open: '{', close: '}', parsePlus: true };
+      var counter = 0;
+      try {
+        ejs.renderFile('test/fixtures/user.ejs', options, function(err, html){
+          counter++;
+          if (err) {
+            err.message.should.not.equal('Exception in callback');
+            return done(err);
+          }
+          throw new Error('Exception in callback');
+        });
+      } catch (err) {
+        counter.should.equal(1);
+        err.message.should.equal('Exception in callback');
+        done();
+      }
+    })
+  })
+
+  describe('<%=', function(){
+    it('should escape', function(){
+      ejs.render('<%= name %>', { name: '<script>', parsePlus: true })
+        .should.equal('&lt;script&gt;');
+    })
+  })
+
+  describe('<%-', function(){
+    it('should not escape', function(){
+      ejs.render('<%- name %>', { name: '<script>', parsePlus: true })
+        .should.equal('<script>');
+    })
+  })
+
+  describe('%>', function(){
+    it('should produce newlines', function(){
+      ejs.render(fixture('newlines.ejs'), { users: users, parsePlus: true })
+        .should.equal(fixture('newlines.html'));
+    })
+  })
+
+  describe('-%>', function(){
+    it('should not produce newlines', function(){
+      ejs.render(fixture('no.newlines.ejs'), { users: users, parsePlus: true })
+        .should.equal(fixture('no.newlines.html'));
+    })
+  })
+
+  describe('single quotes', function(){
+    it('should not mess up the constructed function', function(){
+      ejs.render(fixture('single-quote.ejs'), { parsePlus: true })
+        .should.equal(fixture('single-quote.html'));
+    })
+  })
+
+  describe('double quotes', function(){
+    it('should not mess up the constructed function', function(){
+      ejs.render(fixture('double-quote.ejs'), { parsePlus: true })
+        .should.equal(fixture('double-quote.html'));
+    })
+  })
+
+  describe('backslashes', function(){
+    it('should escape', function(){
+      ejs.render(fixture('backslash.ejs'), { parsePlus: true })
+        .should.equal(fixture('backslash.html'));
+    })
+  })
+
+  describe('messed up whitespace', function(){
+    it('should work', function(){
+      ejs.render(fixture('messed.ejs'), { users: users, parsePlus: true })
+        .should.equal(fixture('messed.html'));
+    })
+  })
+
+  describe('filters', function(){
+    it('should work', function(){
+      var items = ['foo', 'bar', 'baz'];
+      ejs.render('<%=: items | reverse | first | reverse | capitalize %>', { items: items, parsePlus: true })
+        .should.equal('Zab');
+    })
+
+    it('should accept arguments', function(){
+      ejs.render('<%=: users | map:"name" | join:", " %>', { users: users, parsePlus: true })
+        .should.equal('tobi, loki, jane');
+    })
+
+    it('should accept arguments containing :', function(){
+      ejs.render('<%=: users | map:"name" | join:"::" %>', { users: users, parsePlus: true })
+        .should.equal('tobi::loki::jane');
+    })
+  })
+
+  describe('exceptions', function(){
+    it('should produce useful stack traces', function(done){
+      try {
+        ejs.render(fixture('error.ejs'), { filename: 'error.ejs', parsePlus: true });
+      } catch (err) {
+        err.path.should.equal('error.ejs');
+        err.stack.split('\n').slice(0, 8).join('\n').should.equal(fixture('error.out'));
+        done();
+      }
+    })
+
+    it('should not include __stack if compileDebug is false', function() {
+      try {
+        ejs.render(fixture('error.ejs'), {
+          filename: 'error.ejs',
+          compileDebug: false,
+          parsePlus: true
+        });
+      } catch (err) {
+        err.should.not.have.property('path');
+        err.stack.split('\n').slice(0, 8).join('\n').should.not.equal(fixture('error.out'));
+      }
+    });
+  })
+
+  describe('includes', function(){
+    it('should include ejs', function(){
+      var file = 'test/fixtures/include.ejs';
+      ejs.render(fixture('include.ejs'), { filename: file, pets: users, open: '[[', close: ']]', parsePlus: true })
+        .should.equal(fixture('include.html'));
+    })
+
+    it('should work when nested', function(){
+      var file = 'test/fixtures/menu.ejs';
+      ejs.render(fixture('menu.ejs'), { filename: file, pets: users, parsePlus: true })
+        .should.equal(fixture('menu.html'));
+    })
+
+    it('should include arbitrary files as-is', function(){
+      var file = 'test/fixtures/include.css.ejs';
+      ejs.render(fixture('include.css.ejs'), { filename: file, pets: users, parsePlus: true })
+        .should.equal(fixture('include.css.html'));
+    })
+
+    it('should pass compileDebug to include', function(){
+      var file = 'test/fixtures/include.ejs';
+      var fn = ejs.compile(fixture('include.ejs'), 
+        { filename: file, open: '[[', close: ']]', compileDebug: false, client: true, parsePlus: true })
+      var str = fn.toString();
+      eval('var preFn = ' + str);
+      str.should.not.match(/__stack/);
+      (function() {
+        preFn({ pets: users });
+      }).should.not.throw();
+    })
+  })
+
+  describe('comments', function() {
+    it('should fully render with comments removed', function() {
+      ejs.render(fixture('comments.ejs'), { parsePlus: true })
+        .should.equal(fixture('comments.html'));
+    })
+  })
+})


### PR DESCRIPTION
Add a new `parse` function, using `buf +` instead of `buf.push()` for string concat.

It will improve performance.

My benchmark result:

``` bash
$ node benchmark2.js

renderNoCompileDebugNoWith source:

var buf = [];
 buf.push('');1; if (locals.user) { ; buf.push('\n  <h2>hello, ', escape((2,  locals.user.name )), ' ', escape((2,  locals.user.not_exists )), '</h2>\n  <p>', (3,  locals.user.title ), '</p>\n');4; } ; buf.push('');
return buf.join('');
--------------------------------------------------------------
render_ParsePlus_NoCompileDebugNoWith source:

var buf = "";
 buf += '';1; if (locals.user) { ; buf += '\n  <h2>hello, ' + escape((2,  locals.user.name )) + ' ' + escape((2,  locals.user.not_exists )) + '</h2>\n  <p>' + (3,  locals.user.title ) + '</p>\n';4; } ; buf += '';
return buf;
--------------------------------------------------------------
render: 
  <h2>hello, fengmk2 undefined</h2>
  <p></p>

renderNoWith: 
  <h2>hello, fengmk2 undefined</h2>
  <p></p>

renderNoCompileDebug: 
  <h2>hello, fengmk2 undefined</h2>
  <p></p>

renderNoCompileDebugNoWith: 
  <h2>hello, fengmk2 undefined</h2>
  <p></p>

render_ParsePlus_NoWith: 
  <h2>hello, fengmk2 undefined</h2>
  <p>undefined</p>

render_ParsePlus: 
  <h2>hello, fengmk2 undefined</h2>
  <p>undefined</p>

render_ParsePlus_NoCompileDebugNoWith: 
  <h2>hello, fengmk2 undefined</h2>
  <p>undefined</p>

render() x 150,062 ops/sec ±0.93% (96 runs sampled)
renderNoCompileDebug() x 173,700 ops/sec ±1.32% (90 runs sampled)
renderNoWith() x 315,558 ops/sec ±1.19% (91 runs sampled)
renderNoCompileDebugNoWith() x 354,070 ops/sec ±1.51% (90 runs sampled)
render_ParsePlus() x 183,668 ops/sec ±0.76% (96 runs sampled)
render_ParsePlus_NoWith() x 547,998 ops/sec ±0.94% (93 runs sampled)
render_ParsePlus_NoCompileDebugNoWith() x 608,255 ops/sec ±0.92% (95 runs sampled)
Fastest is render_ParsePlus_NoCompileDebugNoWith()
```
