### PR TITLE
Should exclude path too when used in browser.

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -11,7 +11,6 @@
 
 var utils = require('./utils')
   , path = require('path')
-  , basename = path.basename
   , dirname = path.dirname
   , extname = path.extname
   , join = path.join

--- a/support/compile.js
+++ b/support/compile.js
@@ -121,6 +121,7 @@ var browser = {
   
   require: function require(p){
     if ('fs' == p) return {};
+    if ('path' == p) return {};
     var path = require.resolve(p)
       , mod = require.modules[path];
     if (!mod) throw new Error('failed to require "' + p + '"');


### PR DESCRIPTION
Hi TJ,

I am trying to use EJS in the browser, but the `ejs.js/ejs.min.js` is too old, need to compiled again. And the `path` should exclude also.
