### PR TITLE
fixes require, closes #78

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -342,9 +342,12 @@ exports.__express = exports.renderFile;
  */
 
 if (require.extensions) {
-  require.extensions['.ejs'] = function(module, filename) {
-    source = require('fs').readFileSync(filename, 'utf-8');
-    module._compile(compile(source, {}), filename);
+  require.extensions['.ejs'] = function (module, filename) {
+    filename = filename || module.filename;
+    var options = { filename: filename, client: true }
+      , template = fs.readFileSync(filename).toString()
+      , fn = compile(template, options);
+    module._compile('module.exports = ' + fn.toString() + ';', filename);
   };
 } else if (require.registerExtension) {
   require.registerExtension('.ejs', function(src) {

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -263,3 +263,13 @@ describe('comments', function() {
       .should.equal(fixture('comments.html'));
   })
 })
+
+
+describe('require', function() {
+  it('should allow ejs templates to be required as node modules', function() {
+      var file = 'test/fixtures/include.ejs'
+        , template = require(__dirname + '/fixtures/menu.ejs');
+      template({ filename: file, pets: users })
+        .should.equal(fixture('menu.html'));
+  })
+})


### PR DESCRIPTION
Being able to require ejs files would be useful for build systems based on Node.js (such as one I'm working on atm).  Anyway, it was a simple fix, should have no effect on ejs otherwise (e.g. likelihood of regressions is nil), and I've added a test for it.  This PR would close #78.
