### PR TITLE
Fix buf is undefined in IE

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -1,4 +1,3 @@
-
 /*!
  * EJS
  * Copyright(c) 2012 TJ Holowaychuk <tj@vision-media.ca>
@@ -113,8 +112,8 @@ var parse = exports.parse = function(str, options){
     , compileDebug = options.compileDebug !== false
     , buf = [];
 
-  buf.push('var buf = [];');
-  if (false !== options._with) buf.push('\nwith (locals || {}) { (function(){ ');
+  buf.push('locals.buf = [];');
+  if (false !== options._with) buf.push('\nwith (locals || { buf: [] }) { (function(){ ');
   buf.push('\n buf.push(\'');
 
   var lineno = 1;
@@ -189,7 +188,7 @@ var parse = exports.parse = function(str, options){
   }
 
   if (false !== options._with) buf.push("'); })();\n} \nreturn buf.join('');")
-  else buf.push("');\nreturn buf.join('');");
+  else buf.push("');\nreturn locals.buf.join('');");
 
   return buf.join('');
 };


### PR DESCRIPTION
IE just will find the `buf` as a property of `locals` but will not to find it in the upper context.
