### PR TITLE
add two Interface Functions for expansion feature

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -118,6 +118,8 @@ exports.parse = function(str, options){
     , open = options.open || exports.open || '<%'
     , close = options.close || exports.close || '%>'
     , filename = options.filename
+    , onIncludeTpl = options.onIncludeTpl || exports.onIncludeTpl
+    , onParseMethod = options.onParseMethod || exports.onParseMethod
     , compileDebug = options.compileDebug !== false
     , buf = [];
 
@@ -168,7 +170,7 @@ exports.parse = function(str, options){
         newOptions.filename = path;
         newOptions._with = false;
 
-        exports.onIncludeTpl(path, filename, newOptions);
+        onIncludeTpl(path, filename, newOptions);
 
         include = read(path, 'utf8');
         include = exports.parse(include, newOptions);
@@ -180,7 +182,7 @@ exports.parse = function(str, options){
       if (js.substr(0, 1) == ':') js = filtered(js);
       if (js) {
         if (js.lastIndexOf('//') > js.lastIndexOf('\n')) js += '\n';
-        js = exports.onParseMethod(js, options);
+        js = onParseMethod(js, options);
         buf.push(prefix, js, postfix);
       }
       i += end - start + close.length - 1;


### PR DESCRIPTION
add `onIncludeTpl` and `onParseMethod` Interface Functions
1. onIncludeTpl: Use it when `parse` meet `include`
2. onParseMethod: Expand methods by using the string between "<%" and "%>"

For Example:[ejs.extend.js](https://github.com/Bacra/node-d2server/blob/45da676cfba19f936797b577680e1435afec88e1/lib/module/parseHTML/ejs.extend.js)

PS: I'm so sorry. [I pull requests before](https://github.com/visionmedia/ejs/pull/125), but the branch is change. Now the two branches are independent.
