### PR TITLE
performance improvements to parse

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -113,9 +113,9 @@ var parse = exports.parse = function(str, options){
     , compileDebug = options.compileDebug !== false
     , buf = "";
 
-  buf += ('var buf = [];');
-  if (false !== options._with) buf += ('\nwith (locals || {}) { (function(){ ');
-  buf += ('\n buf.push(\'');
+  buf += 'var buf = [];';
+  if (false !== options._with) buf += '\nwith (locals || {}) { (function(){ ';
+  buf += '\n buf.push(\'';
 
   var lineno = 1;
 
@@ -159,7 +159,7 @@ var parse = exports.parse = function(str, options){
         var path = resolveInclude(name, filename);
         include = read(path, 'utf8');
         include = exports.parse(include, { filename: path, _with: false, open: open, close: close, compileDebug: compileDebug });
-        buf += ("' + (function(){" + include + "})() + '");
+        buf += "' + (function(){" + include + "})() + '";
         js = '';
       }
 
@@ -174,25 +174,25 @@ var parse = exports.parse = function(str, options){
       i += end - start + close.length - 1;
 
     } else if (stri == "\\") {
-      buf += ("\\\\");
+      buf += "\\\\";
     } else if (stri == "'") {
-      buf += ("\\'");
+      buf += "\\'";
     } else if (stri == "\r") {
       // ignore
     } else if (stri == "\n") {
       if (consumeEOL) {
         consumeEOL = false;
       } else {
-        buf += ("\\n");
+        buf += "\\n";
         lineno++;
       }
     } else {
-      buf += (stri);
+      buf += stri;
     }
   }
 
-  if (false !== options._with) buf += ("'); })();\n} \nreturn buf.join('');")
-  else buf += ("');\nreturn buf.join('');");
+  if (false !== options._with) buf += "'); })();\n} \nreturn buf.join('');";
+  else buf += "');\nreturn buf.join('');";
   return buf;
 };
 


### PR DESCRIPTION
1) Replaced buf.push(...) with buf[buf.length] =
2) Replaced string.substr(i, 1) with string[i]
3) Cached str[i]

Dropped parse times for my test file from ~300ms to ~180ms
