### PR TITLE
[fix] view/model throw object instead of Error

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -87,6 +87,10 @@ function rethrow(err, str, filename, lineno){
       + line;
   }).join('\n');
 
+  // If regular object was thrown instead of Error instance (for example string or Number)
+  if (!(err instanceof Error))
+    err=new Error(err.toString());
+
   // Alter exception message
   err.path = filename;
   err.message = (filename || 'ejs') + ':'
@@ -316,7 +320,13 @@ exports.renderFile = function(path, options, fn){
     fn(err);
     return;
   }
-  fn(null, exports.render(str, options));
+
+  try {
+    fn(null,exports.render(str, options) );
+  } catch (err){
+    fn(err);
+    return;
+  }
 };
 
 /**


### PR DESCRIPTION
In case if view/model is throwing not Error object or it's ancestors stack trace is eaten and error message is mall formed. It don't contain line information and stack trace.

Error page in Express is completely empty, except word Express, object and 500 -- error code. No stack trace and code sample. 
![Error in express server](https://dl.dropboxusercontent.com/u/60790227/error_string.JPG)
and here is same page with my fix:
![Fixed page](https://dl.dropboxusercontent.com/u/60790227/error_exception.JPG)
