### PR TITLE
Fixed infinite loop problem in parse for unescaped ejs

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -92,7 +92,7 @@ function rethrow(err, str, filename, lineno){
     + lineno + '\n'
     + context + '\n\n'
     + err.message;
-  
+
   throw err;
 }
 
@@ -123,7 +123,7 @@ var parse = exports.parse = function(str, options){
     var stri = str[i];
     if (str.slice(i, open.length + i) == open) {
       i += open.length
-  
+
       var prefix, postfix, line = (compileDebug ? '__stack.lineno=' : '') + lineno;
       switch (str[i]) {
         case '=':
@@ -141,8 +141,13 @@ var parse = exports.parse = function(str, options){
           postfix = "; buf.push('";
       }
 
-      var end = str.indexOf(close, i)
-        , js = str.substring(i, end)
+      var end = str.indexOf(close, i);
+
+      if (end < 0){
+        end = str.length;
+      }
+
+      var js = str.substring(i, end)
         , start = i
         , include = null
         , n = 0;
@@ -207,14 +212,14 @@ var parse = exports.parse = function(str, options){
 var compile = exports.compile = function(str, options){
   options = options || {};
   var escape = options.escape || utils.escape;
-  
+
   var input = JSON.stringify(str)
     , compileDebug = options.compileDebug !== false
     , client = options.client
     , filename = options.filename
         ? JSON.stringify(options.filename)
         : 'undefined';
-  
+
   if (compileDebug) {
     // Adds the fancy stack trace meta info
     str = [
@@ -229,7 +234,7 @@ var compile = exports.compile = function(str, options){
   } else {
     str = exports.parse(str, options);
   }
-  
+
   if (options.debug) console.log(str);
   if (client) str = 'escape = escape || ' + escape.toString() + ';\n' + str;
 


### PR DESCRIPTION
This code will run in an infinite loop eventually taking all memory and killing the node process (Allocation failed - process out of memory):

```
var ejs = require('ejs');
var ejsOpts = {
  open: '{{',
  close: '}}'
};
var template = " {{=nik }";
console.log("start");
var compiled = ejs.compile(template, ejsOpts);
console.log("compiled", compiled);

```

The problem is at file lib/ejs.js line 144,173 (prase function)
end  becomes -1 and i(loop counter) always getting set to 1, and the for loop never ends.

This fix solves it because now ejs will throw an error when template being compiled  is unescaped rather than going into infinite loop.
