### PR TITLE
Add a new filter that replaces falsy values with a default value

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -199,3 +199,10 @@ exports.get = function(obj, prop){
 exports.json = function(obj){
   return JSON.stringify(obj);
 };
+
+/**
+ * Sets a default `def` value if `obj` is falsy. Uses an empty string by default.
+ */
+exports.default = function(obj, def) {
+    return obj ? obj : (def || '');
+};

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -231,6 +231,19 @@ describe('filters', function(){
     ejs.render('<%=: users | map:"name" | join:"::" %>', { users: users })
       .should.equal('tobi::loki::jane');
   })
+  
+  it('should convert default values :', function(){
+    [undefined, 0, null, false, ''].forEach(function(value){
+      ejs.render('<%=: value | default:"novalue" %>', { value: value })
+        .should.equal('novalue'); 
+        
+      ejs.render('<%=: value | default %>', { value: value })
+        .should.equal('');
+    });
+    
+    ejs.render('<%=: value | default:"novalue" %>', { value: 'truthy' })
+      .should.equal('truthy');
+    });
 })
 
 describe('exceptions', function(){


### PR DESCRIPTION
Include a filter that checks if a value if falsy and, in that case, replaces it with a default one (passed as an optional argument, empty string by default).

This is useful to make your intention clear (instead of <%= value || "my value" %>) and to combine it with other filters (e.g. <%=: value | default | capitalize %>).

It includes some tests.
