### PR TITLE
Update ejs.js

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -1,4 +1,3 @@
-
 /*!
  * EJS
  * Copyright(c) 2012 TJ Holowaychuk <tj@vision-media.ca>
@@ -42,6 +41,20 @@ var cache = {};
 exports.clearCache = function(){
   cache = {};
 };
+
+/**
+ * Render an EJS file at the given `path` (easton changed)
+ * @param {String} path
+ * @param {String} encoding
+ * @api private
+*/
+function readEJSFile(path, encoding) {
+    var buffer = read(path);
+    if (buffer[0] == 239 && buffer[1] == 187 && buffer[2] == 191) {
+        buffer = buffer.slice(3);
+    }
+    return buffer.toString(encoding);
+}
 
 /**
  * Translate filtered code into function calls.
@@ -161,7 +174,7 @@ var parse = exports.parse = function(str, options){
         var name = js.trim().slice(7).trim();
         if (!filename) throw new Error('filename option is required for includes');
         var path = resolveInclude(name, filename);
-        include = read(path, 'utf8');
+        include = readEJSFile(path, 'utf8');
         include = exports.parse(include, { filename: path, _with: false, open: open, close: close, compileDebug: compileDebug });
         buf += "' + (function(){" + include + "})() + '";
         js = '';
@@ -314,8 +327,8 @@ exports.renderFile = function(path, options, fn){
   var str;
   try {
     str = options.cache
-      ? cache[key] || (cache[key] = read(path, 'utf8'))
-      : read(path, 'utf8');
+      ? cache[key] || (cache[key] = readEJSFile(path, 'utf8'))
+      : readEJSFile(path, 'utf8');
   } catch (err) {
     fn(err);
     return;


### PR DESCRIPTION
identify and remove BOM header.

new function:
line = 52

/**
- Render an EJS file at the given `path` (easton changed)
- @param {String} path
- @param {String} encoding
- @api private
  */
  function readEJSFile(path, encoding) {
  var buffer = read(path);
  if (buffer[0] == 239 && buffer[1] == 187 && buffer[2] == 191) {
      buffer = buffer.slice(3);
  }
  return buffer.toString(encoding);
  }
