### PR TITLE
Use locals as `this` value inside filter functions

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -56,7 +56,7 @@ function filtered(js) {
       , name = parts.shift()
       , args = parts.join(':') || '';
     if (args) args = ', ' + args;
-    return 'filters.' + name + '(' + js + args + ')';
+    return 'filters.' + name + '.call(locals,' + js + args + ')';
   });
 };
 


### PR DESCRIPTION
This little patch changes the value of `this` inside all filter functions to
that of the `locals` object. Currently it seems that `this` is a reference to
the `filters` object. The purpose is to expose additional data to the filter
function without having to pass additional arguments from the template.

This could potentially be a breaking change if users are currently relying on
`this` being a reference to the `filters` object from within their custom
filters. Additional changes could be relatively easily made to make this
configurable.
