### PR TITLE
use implicit string conversion instead of String constructor

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -168,7 +168,7 @@ var parse = exports.parse = function(str, options){
 
       while (~(n = js.indexOf("\n", n))) n++, lineno++;
       
-      switch(js.substr(0, 1)) {
+      switch(js[0]) {
         case ':':
           js = filtered(js);
           break;

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -25,7 +25,7 @@ exports.last = function(obj) {
  */
 
 exports.capitalize = function(str){
-  str = String(str);
+  str = str + '';
   return str[0].toUpperCase() + str.substr(1, str.length);
 };
 
@@ -34,7 +34,7 @@ exports.capitalize = function(str){
  */
 
 exports.downcase = function(str){
-  return String(str).toLowerCase();
+  return (str + '').toLowerCase();
 };
 
 /**
@@ -42,7 +42,7 @@ exports.downcase = function(str){
  */
 
 exports.upcase = function(str){
-  return String(str).toUpperCase();
+  return (str + '').toUpperCase();
 };
 
 /**
@@ -119,7 +119,7 @@ exports.join = function(obj, str){
  */
 
 exports.truncate = function(str, len, append){
-  str = String(str);
+  str += '';
   if (str.length > len) {
     str = str.slice(0, len);
     if (append) str += append;
@@ -132,7 +132,7 @@ exports.truncate = function(str, len, append){
  */
 
 exports.truncate_words = function(str, n){
-  var str = String(str)
+  var str = str + ''
     , words = str.split(/ +/);
   return words.slice(0, n).join(' ');
 };
@@ -142,7 +142,7 @@ exports.truncate_words = function(str, n){
  */
 
 exports.replace = function(str, pattern, substitution){
-  return String(str).replace(pattern, substitution || '');
+  return (str + '').replace(pattern, substitution || '');
 };
 
 /**


### PR DESCRIPTION
Hi,
I would propose few optimizations:

1) Use implicit string conversion, instead of String constructor. Especially if the expected input is string, like in functions: capitalize, downcase, upcase, truncate, truncate_words and replace (jsperf test: http://jsperf.com/implicitstringconversion)

2) Instead of js.substr(0,1), use equivalent js[0]. 
