### PR TITLE
fix: examples/list.ejs

### DIFF
--- a/examples/list.ejs
+++ b/examples/list.ejs
@@ -1,7 +1,7 @@
 <% if (names.length) { %>
   <ul>
     <% names.forEach(function(name){ %>
-      <li foo='<%= name + "'" %>'><%= name %></li>
+      <li foo='<%= name %>'><%= name %></li>
     <% }) %>
   </ul>
 <% } %>


### PR DESCRIPTION
remove ` + "'"`
it makes some plugins go wrong